### PR TITLE
Bug fixing

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,33 +54,43 @@ define(function (require, exports, module) {
     /**
      * @private
      */
-    function _openSelectedDir() {
+    function _cmdOpen() {
+        _isCmdAction = true;
+
         var item = ProjectManager.getSelectedItem(),
+            project = ProjectManager.getProjectRoot(),
             path;
 
-        // get the cwd according to selection
-        if (item.isDirectory) {
-            path = item.fullPath;
-        } else {
-            path = item.parentPath;
-        }
+        if (item) {
+            if (item.isDirectory) {
+                path = item.fullPath;
+            } else if (item.parentPath !== project.fullPath) {
+                path = item.parentPath;
+            }
 
-        ProjectManager.openProject(path);
+            // add current project path to stack and update back command if needed
+            _openNewProjectIfNeeded(project, path);
+        }
+    }
+
+    /**
+    *  @private
+    */
+    function _openNewProjectIfNeeded(currentProject, newPath) {
+        if (currentProject && newPath) {
+            _addProjectToStack(currentProject);
+            ProjectManager.openProject(newPath);
+        }
     }
 
     /**
      * @private
      */
-    function _cmdOpen() {
-        _isCmdAction = true;
-        // add current project path to stack and update back command
-        var project = ProjectManager.getProjectRoot();
+    function _addProjectToStack(project) {
         if (project) {
             _pathStack.push(project.fullPath);
             _toggleBackCmdIfNeeded();
         }
-
-        _openSelectedDir();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "albertinad.open-as-project",
     "title": "Open as Project",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Open as Project is a Brackets extension that lets you select an entry from the Project Tree View, and open it as a project, and then navigate back to the previous selection, using the Project Contextual Menu.",
     "homepage": "https://github.com/albertinad/open-as-project",
     "repository": {


### PR DESCRIPTION
There were some bugs related to the opening of projects when the current
selected file was directly located in the root folder. In that case,
the same current project was added to the stack. The same happened when
using open as project without any file selected.